### PR TITLE
Updating chapters listing and fixing css bug in footer

### DIFF
--- a/app/assets/stylesheets/modules/about.scss
+++ b/app/assets/stylesheets/modules/about.scss
@@ -1,27 +1,29 @@
 // chapters
 
 #chapters {
-  h2 {
-    border-bottom: 1px solid $gray;
-    padding-bottom: 15px;
-    margin-top: 20px;
-  }
-  .chapter-box {
-    float: left;
-    width: 207px;
-    height: 115px;
-    border: 1px solid $gray;
-    padding: 15px 20px;
-    margin: 5px 10px 10px 0;
-    ul {
-      margin: 0;
-      list-style: none;
-      li {
-        margin-bottom: 5px;
-      }
+  .content {
+    h2 {
+      border-bottom: 1px solid $gray;
+      padding-bottom: 15px;
+      margin-top: 20px;
     }
-    h4 {
-      margin: 0 0 10px 0;
+    .chapter-box {
+      float: left;
+      width: 207px;
+      height: 115px;
+      border: 1px solid $gray;
+      padding: 15px 20px;
+      margin: 5px 10px 10px 0;
+      ul {
+        margin: 0;
+        list-style: none;
+        li {
+          margin-bottom: 5px;
+        }
+      }
+      h4 {
+        margin: 0 0 10px 0;
+      }
     }
   }
 }

--- a/app/views/static_pages/chapters.html.haml
+++ b/app/views/static_pages/chapters.html.haml
@@ -2,8 +2,7 @@
 
 %h1 RailsBridge Chapters.
 %hr/
-%p
-  Some chapters have workshops yearly, some quarterly, and some monthly. Check 'em out!
+%p Some chapters have workshops yearly, some quarterly, and some monthly. Check 'em out!
 .feature-standalone
   .feature.clearfix
     .feature-icon.icon-3x.icon-rocket
@@ -16,105 +15,127 @@
   .span12
     %h2 West Coast
     .chapter-box.clearfix
-      %h4 RailsBridge San Francisco
+      %h4 Los Angeles, California
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.sfruby.info"} sfruby.info
-        %li
-          Follow
-          %a{:href => "http://www.twitter.com/railsbridge"} @RailsBridge
-          for updates!
+          %a{ href: "http://www.meetup.com/Los-Angeles-Womens-Ruby-on-Rails-Group/", target: "_blank" } meetup.com/Los-Angeles-Womens-Ruby-on-Rails-Group
     .chapter-box.clearfix
-      %h4 RailsBridge Silicon Valley
+      %h4 San Diego, California
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/silicon-valley-ruby/"} meetup.com/silicon-valley-ruby
+          %a{ href: "http://www.meetup.com/San-Diego-RailsBridge/", target: "_blank" } meetup.com/San-Diego-RailsBridge
         %li
           Twitter:
-          %a{:href => "https://twitter.com/railsbridgeSV"} @RailsBridgeSV
+          %a{ href: "http://www.twitter.com/railsbridgesd", target: "_blank" } @RailsBridgeSD
     .chapter-box.clearfix
-      %h4 RailsBridge LA
+      %h4 San Francisco, California
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/Los-Angeles-Womens-Ruby-on-Rails-Group/"} meetup.com/Los-Angeles-Womens-Ruby-on-Rails-Group
+          %a{ href: "http://www.sfruby.info", target: "_blank" } sfruby.info
+        %li
+          Follow
+          %a{ href: "http://www.twitter.com/railsbridge", target: "_blank" } @RailsBridge
+          for updates!
     .chapter-box.clearfix
-      %h4 RailsBridge San Diego
+      %h4 Seattle, Washington
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/San-Diego-RailsBridge/"} meetup.com/San-Diego-RailsBridge
-        %li
-          On Twitter:
-          %a{:href => "http://www.twitter.com/railsbridgesd"} @RailsBridgeSD
+          %a{ href: "http://www.meetup.com/SeattleRailsBridge/", target: "_blank" } meetup.com/SeattleRailsBridge
     .chapter-box.clearfix
-      %h4 RailsBridge Seattle
+      %h4 Silicon Valley, California
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/SeattleRailsBridge/"} meetup.com/SeattleRailsBridge
+          %a{ href: "http://www.meetup.com/silicon-valley-ruby/", target: "_blank" } meetup.com/silicon-valley-ruby
+        %li
+          Twitter:
+          %a{ href: "https://twitter.com/railsbridgeSV", target: "_blank" } @RailsBridgeSV
 .row-fluid
   .span12
     %h2 Central
-    .chapter-box
-      %h4 RailsBridge Denver/Boulder/Ft Collins
+    .chapter-box.clearfix
+      %h4 Chicago, Illinois
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/Boulder-Denver-Railsbridge/"} meetup.com/Boulder-Denver-Railsbridge
+          %a{ href: "http://www.meetup.com/Chicago-Ruby-on-Rails-Outreach-Workshop-for-Women/", target: "_blank" } meetup.com/Chicago-Ruby-on-Rails-Outreach-Workshop-for-Women
     .chapter-box.clearfix
-      %h4 RailsBridge Minnesota
-      %ul
-        %li
-          On Twitter:
-          %a{:href => "https://twitter.com/railsbridgeMN"} @railsbridgeMN
-    .chapter-box.clearfix
-      %h4 RailsBridge Chicago
+      %h4 Denver/Boulder/Fort Collins, Colorado
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/Chicago-Ruby-on-Rails-Outreach-Workshop-for-Women/"} meetup.com/Chicago-Ruby-on-Rails-Outreach-Workshop-for-Women
+          %a{ href: "http://www.meetup.com/Boulder-Denver-Railsbridge/", target: "_blank" } meetup.com/Boulder-Denver-Railsbridge
+    .chapter-box.clearfix
+      %h4 Minnesota
+      %ul
+        %li
+          Twitter:
+          %a{ href: "https://twitter.com/railsbridgeMN", target: "_blank" } @railsbridgeMN
 .row-fluid
   .span12
     %h2 East Coast
     .chapter-box.clearfix
-      %h4 RailsBridge Boston
+      %h4 Boston, Massachusetts
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.railsbridgeboston.org"} railsbridgeboston.org
+          %a{ href: "http://www.railsbridgeboston.org", target: "_blank" } railsbridgeboston.org
         %li
           Twitter:
-          %a{:href => "https://twitter.com/RailsBridgeBos"} @RailsBridgeBos
+          %a{ href: "https://twitter.com/RailsBridgeBos", target: "_blank" } @RailsBridgeBos
         %li
-          %a{:href => "https://groups.google.com/forum/#!forum/railsbridge-boston-alumni"} Boston alumni mailing list
+          %a{ href: "https://groups.google.com/forum/#!forum/railsbridge-boston-alumni", target: "_blank" } Boston alumni mailing list
     .chapter-box.clearfix
-      %h4 RailsBridge Panama City
+      %h4 Kentucky
+      %ul
+        %li
+          Twitter:
+          %a{ href: "https://twitter.com/railsbridgeky", target: "_blank" } @RailsBridgeKY
+
+
+    .chapter-box.clearfix
+      %h4 New York City, New York
+      %ul
+        %li
+          %a{ href: "http://railsbridgenyc.org/", target: "_blank" } railsbridgenyc.org
+        %li
+          Twitter:
+          %a{ href: "https://twitter.com/RailsBridgeNYC", target: "_blank" } @RailsBridgeNYC
+    .chapter-box.clearfix
+      %h4 Panama City, Florida
       %ul
         %li
           Sign up at
-          %a{:href => "http://www.meetup.com/pixelworkers/"} meetup.com/pixelworkers
+          %a{ href: "http://www.meetup.com/pixelworkers/", target: "_blank" } meetup.com/pixelworkers
         %li
           Online at:
-          %a{:href => "http://railsbridgepc.github.com/"} railsbridgepc.github.com
+          %a{ href: "http://railsbridgepc.github.com/", target: "_blank" } railsbridgepc.github.com
     .chapter-box.clearfix
-      %h4 RailsBridge Kentucky
+      %h4 Savannah, Georgia
       %ul
         %li
-          On Twitter:
-          %a{:href => "https://twitter.com/railsbridgeky"} @RailsBridgeKY
+          Sign up at:
+          %a{ href: "http://rubysavannah.com/", target: "_blank" } rubysavannah.com
+
 .row-fluid
   .span12
     %h2 Canada & Global
     .chapter-box.clearfix
-      %h4 RailsBridge Montreal
+      %h4 Montr&eacute;al, Quebec
       %ul
         %li
           Sign up at at
-          %a{:href => "http://www.railsbridge-montreal.com/"} railsbridge-montreal.com
+          %a{ href: "http://www.railsbridge-montreal.com/", target: "_blank" } railsbridge-montreal.com
     .chapter-box.clearfix
-      %h4 RailsBridge Global
+      %h4 Capetown, South Africa
       %ul
-        %li Events happen in places where RailsBridge volunteers go, especially in conjunction with conferences!
+        %li
+          %a{ href: "http://railsbridgecapetown.org/", target: "_blank" } railsbridgecapetown.org
+    .chapter-box.clearfix
+      %h4
+      %ul
+        %li Events also happen in places where RailsBridge volunteers go, especially in conjunction with conferences!


### PR DESCRIPTION
Adding NYC, Capetown, Savannah and adding more specificity to chapter css to keep footer from being affected, had rogue underline.
