### PR TITLE
Fix for bridgetroll links - urgent

### DIFF
--- a/app/views/layouts/_event.html.haml
+++ b/app/views/layouts/_event.html.haml
@@ -10,4 +10,4 @@
     %li= link_to raw("<span class='icon-user'></span>Organized by #{event.organizers.first} & friends"), '', class: 'event-host'
     - if event.location
       %li= link_to raw("<span class='icon-map-marker'></span>Held at #{event.location.name}"), '', class: 'event-venue'
-  = link_to 'RSVP on Bridge Troll', "http://bridgetroll-staging.herokuapp.com/events/#{event.id}", class: 'event-cta'
+  = link_to 'RSVP on Bridge Troll', "http://www.bridgetroll.org/events/#{event.id}", class: 'event-cta'

--- a/app/views/static_pages/past_events.html.haml
+++ b/app/views/static_pages/past_events.html.haml
@@ -23,7 +23,7 @@
     %tr
       %td 107
       %td
-        %a{:href => "http://bridgetroll.herokuapp.com/events/58", :target => "_blank"} August 23-24, 2013
+        %a{:href => "http://www.bridgetroll.org/events/58", :target => "_blank"} August 23-24, 2013
       %td San Francisco
       %td Thoughtbot
       %td Jessie Young


### PR DESCRIPTION
Heya, this should be merged asap, the bridgetroll link on the events page is pointing towards a link aggravator site.
