### PR TITLE
Increase clickable area for side nav links

### DIFF
--- a/app/assets/stylesheets/layout/_side-nav.css.scss
+++ b/app/assets/stylesheets/layout/_side-nav.css.scss
@@ -3,12 +3,6 @@
   .side-nav {
     margin-bottom: 20px;
     border: 1px solid $gray;
-    .side-nav-links {
-      display: none;
-    }
-    .is-selected {
-      display: block;
-    }
     a {
       color: $black;
     }
@@ -18,7 +12,10 @@
       li {
         text-align: center;
         line-height: 18px;
-        padding: 12px 20px;
+        a {
+          display: block;
+          padding: 12px 20px;
+        }
         &.is-selected {
           background: $blue;
           &:hover {
@@ -44,12 +41,6 @@
 @media (max-width: 768px) {
   .side-nav {
     margin: 10px 0;
-    .side-nav-links {
-      display: none;
-    }
-    .is-selected {
-      display: inline-block;
-    }
     a {
       color: $black;
     }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  before_filter :assign_nav_group
+
   @suppress_sidenav = false
 
   def home
@@ -57,4 +59,11 @@ class StaticPagesController < ApplicationController
   def interest_form
   end
 
+  private
+
+  def assign_nav_group
+    [:learn, :help, :about].each do |group|
+      @nav_group = group if request.path.match(/^\/#{group}/)
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,34 @@ module ApplicationHelper
     title ? "#{base_title} | #{title.join(' | ')}" : base_title
   end
 
+  def nav_links_by_group
+    {
+      learn: [
+        ["Overview", :learn],
+        ["Upcoming Workshops", :events],
+        ["FAQ", :learning_faq],
+        ["Keep Learning", :learning_resources],
+      ],
+      help: [
+        ["Overview", :help],
+        ["Teach or TA", :teach],
+        ["Advice for Teachers", :teacher_advice],
+        ["Organize an Event", :organize],
+        ["Host an Event", :host],
+        ["Donor FAQ", :donor_faq],
+        ["Interest Form", :interest_form]
+      ],
+      about: [
+        ["Overview", :about],
+        ["Team", :team],
+        ["Sponsors ", :sponsors],
+        ["Chapters", :chapters],
+        ["Past Events", :past_events],
+        ["Projects", :projects]
+      ]
+    }
+  end
+
   def nav_link(link_text, link)
     class_name = current_page?(link) ? 'is-selected' : ''
     content_tag(:li, class: class_name) do

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,20 +3,20 @@
     = link_to :root, class: "logo" do
       %h1 RailsBridge
     %ul.header-nav.nav
-      %li#learn.nav-link{ class: ("is-selected" if request.path.match(/^\/learn/)) }
+      %li#learn.nav-link{ class: ("is-selected" if @nav_group == :learn) }
         = link_to "Learn", :learn
         %span
         %ul.dropdown-menu{ role: "menu", :"aria-labelledby" => "dLabel" }
-          = render "layouts/nav_links", nav_group: "learn"
-      %li#help.nav-link{ class: ("is-selected" if request.path.match(/^\/help/)) }
+          = render "layouts/nav_links", nav_group: :learn
+      %li#help.nav-link{ class: ("is-selected" if @nav_group == :help) }
         = link_to "Help", :help
         %span
         %ul.dropdown-menu{ role: "menu", :"aria-labelledby" => "dLabel" }
-          = render "layouts/nav_links", nav_group: "help"
-      %li#about.nav-link{ class: ("is-selected" if request.path.match(/^\/about/)) }
+          = render "layouts/nav_links", nav_group: :help
+      %li#about.nav-link{ class: ("is-selected" if @nav_group == :about) }
         = link_to "About", :about
         %span
         %ul.dropdown-menu{ role: "menu", :"aria-labelledby" => "dLabel" }
-          = render "layouts/nav_links", nav_group: "about"
+          = render "layouts/nav_links", nav_group: :about
       %li.external#blog= link_to "Blog", "http://workshops.railsbridge.org/blog", target: "_blank"
       %li.external#curriculum= link_to "Curriculum & Installfest", "http://docs.railsbridge.org", target: "_blank"

--- a/app/views/layouts/_nav_links.html.haml
+++ b/app/views/layouts/_nav_links.html.haml
@@ -1,22 +1,2 @@
-- if nav_group == "learn"
-  = nav_link "Overview", :learn
-  = nav_link "Upcoming Workshops", :events
-  = nav_link "FAQ", :learning_faq
-  = nav_link "Keep Learning", :learning_resources
-
-- if nav_group == "help"
-  = nav_link "Overview", :help
-  = nav_link "Teach or TA", :teach
-  = nav_link "Advice for Teachers", :teacher_advice
-  = nav_link "Organize an Event", :organize
-  = nav_link "Host an Event", :host
-  = nav_link "Donor FAQ", :donor_faq
-  = nav_link "Interest Form", :interest_form
-
-- if nav_group == "about"
-  = nav_link "Overview", :about
-  = nav_link "Team", :team
-  = nav_link "Sponsors ", :sponsors
-  = nav_link "Chapters", :chapters
-  = nav_link "Past Events", :past_events
-  = nav_link "Projects", :projects
+- nav_links_by_group[nav_group].each do |(link_title, link)|
+  = nav_link link_title, link

--- a/app/views/layouts/_side_nav.html.haml
+++ b/app/views/layouts/_side_nav.html.haml
@@ -1,7 +1,3 @@
 .side-nav
-  %ul.side-nav-links{ class: ("is-selected" if request.path.match(/^\/learn/)) }
-    = render "layouts/nav_links", nav_group: "learn"
-  %ul.side-nav-links{ class: ("is-selected" if request.path.match(/^\/help/)) }
-    = render "layouts/nav_links", nav_group: "help"
-  %ul.side-nav-links{ class: ("is-selected" if request.path.match(/^\/about/)) }
-    = render "layouts/nav_links", nav_group: "about"
+  %ul
+    = render "layouts/nav_links", nav_group: @nav_group


### PR DESCRIPTION
Previously, it was a small 'a' in a big 'ul'. Now the 'a' takes up the full size.

ALSO, refactored nav link data in general to live in a 'nav_links_by_group'
helper, which is the master list of nav links.

This helps move some logic away from the templates so we can be a little more
precise about where and how nav links are rendered.
