### PR TITLE
Add link to Bridge Troll project on Github

### DIFF
--- a/app/views/static_pages/help.html.haml
+++ b/app/views/static_pages/help.html.haml
@@ -54,7 +54,7 @@
       .feature-icon.icon-wrench
       %h4 Help build new tools
       %ul.bulleted
-        %li Help us improve Bridge Troll, our open source event management app.
+        %li Help us improve #{link_to "Bridge Troll", "https://github.com/railsbridge/bridge_troll"}, our open source event management app.
         %li Students always wonder what to do next, and we'd like to build better tools for helping them figure out their next steps.
 
 .row-fluid.help.js-match-height


### PR DESCRIPTION
Small tweak. This just turns the "Bridge Troll" text into a link so people can more easily access the project.
