### PR TITLE
Add link to Omniref to ruby resources page

### DIFF
--- a/app/views/static_pages/resources/_ruby_resources.html.haml
+++ b/app/views/static_pages/resources/_ruby_resources.html.haml
@@ -35,10 +35,16 @@
     — focuses on writing idiomatic Ruby rather than programming skills or concepts.
 %h4 Reference and Documentation
 %ul
-  %li 
+  %li
     #{ link_to "Ruby documentation", "http://www.ruby-doc.org/"}
     \&mdash;
     it's great to just read through the available methods for #{ link_to "strings", "http://ruby-doc.org/core-2.0/String.html" }, #{ link_to "arrays", "http://www.ruby-doc.org/core-2.0/Array.html" }, #{ link_to "hashes", "http://www.ruby-doc.org/core-2.0/Hash.html" }, and the #{ link_to "enumerable mixin", "http://ruby-doc.org/core-2.0/Enumerable.html" }.
+  %li
+    Omniref.com #{ link_to "ruby and gem documentation", "https://www.omniref.com/" }
+    \&mdash;
+    This site has the complete documentation for every version of Ruby, and every version of every Ruby Gem, like #{ link_to "activerecord", "https://www.omniref.com/ruby/gems/activerecord" }, #{ link_to "json", "https://www.omniref.com/ruby/gems/json"}, and #{ link_to "rake", "https://www.omniref.com/ruby/gems/rake" }.
+    It\'s also a great place to leave questions about code you don\'t understand well, like this example on #{ link_to "ActiveRecord.all", "https://www.omniref.com/ruby/gems/activerecord/4.1.1/symbols/ActiveRecord::Scoping::Named#annotation=28"}.
+
 %h4 Object Oriented Programming
 %ul
   %li #{ link_to "Practical Object-Oriented Design in Ruby", "http://www.poodr.info/" } (or POODR for short) is the book on object-oriented design by rockstar Sandi Metz.


### PR DESCRIPTION
Rachel Myers suggested that I add a link to Omniref.com to the resources page, since it's probably very useful for your students.