### PR TITLE
Make clicktarget for subnav links larger.

### DIFF
--- a/app/assets/stylesheets/layout/_subnav.css.scss
+++ b/app/assets/stylesheets/layout/_subnav.css.scss
@@ -23,6 +23,7 @@
       margin-right: 30px;
       a {
         color: lighten($blue, 40%);
+        display: block;
         &:hover {
           color: $white;
         }


### PR DESCRIPTION
Addresses #56.

Also possible to move the `margin-right: 30px` from the `li` to padding on the `a` (0 15px), which would make the target even more clickable, but I didn't want to mess with that too much, especially since we'd also need to look at the responsive views. Happy to experiment further, if warranted.
