### PR TITLE
Add RailsBridgeTriangle to chapters

### DIFF
--- a/app/views/static_pages/chapters.html.haml
+++ b/app/views/static_pages/chapters.html.haml
@@ -210,6 +210,17 @@
           Follow
           %a{ href: "https://twitter.com/RailsBridgeNYC", target: "_blank" } @RailsBridgeNYC
           for updates!
+  .col-md-4
+    .feature.js-match-height-item
+      %h4 Raleigh/Durham/Chapel Hill, North Carolina
+      %ul
+        %li
+          Online at
+          %a{ href: "http://railsbridgetriangle.com/", target: "_blank" } railsbridgetriangle.com
+        %li
+          Follow
+          %a{ href: "https://twitter.com/RailsBridgeTri", target: "_blank" } @RailsBridgeTri
+          for updates!
 
 %h2.gray-underline Canada & Global
 


### PR DESCRIPTION
This adds links for [RailsBridgeTriangle](http://railsbridgetriangle.com/) located in Raleigh/Durham/Chapel Hill, North Carolina to the chapters page.