### PR TITLE
Replace School Foundry references with Bridge Foundry

### DIFF
--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -47,10 +47,7 @@
     You are! Or perhaps you will be in the future. RailsBridge is extremely non-hierarchical,
     and we believe strongly that we should have a high #{ link_to "bus number", "http://en.wikipedia.org/wiki/Bus_factor", class: 'inline-link' }.
     As an organization whose output is entirely #{ link_to "open source", "http://en.wikipedia.org/wiki/Open_source", class: 'inline-link' },
-    all of RailsBridge's growth is a result of the efforts of members of the community &mdash; people who see an opportunity
-    for improvement and make it happen. Legally, RailsBridge is a project of Bridge Foundry, which itself is part of
-    #{ link_to "School Factory", "http://schoolfactory.org/", class: 'inline-link' }, an organization that creates and supports communities
-    and spaces that transform education.
+    all of RailsBridge's growth is a result of the efforts of members of the community &mdash; people who see an opportunity for improvement and make it happen. Legally, RailsBridge is a project of #{ link_to "Bridge Foundry, Inc.", "https://bridgefoundry.org/", class: 'inline-link' }, a non-profit organization that transforms tech culture by generating leaders, teachers and mentors who empower the underserved.
 
   %h2 Want more?
   %p Here are just a few writeups about RailsBridge and its impact on individual people and the larger Ruby community:

--- a/app/views/static_pages/donate.html.haml
+++ b/app/views/static_pages/donate.html.haml
@@ -11,7 +11,7 @@
     have companies to help sponsor and host!
 
   %p
-    RailsBridge works with #{ link_to "School Factory", "http://schoolfactory.org/", class: 'inline-link' }, a 501(c)3 charitable organization, so that we're
+    RailsBridge works with #{ link_to "Bridge Foundry", "https://bridgefoundry.org/", class: 'inline-link' }, a 501(c)3 charitable organization, so that we're
     able to accept tax deductible donations.
 
   %p
@@ -22,9 +22,9 @@
   %h5 Support RailsBridge:
   %form{action: "https://www.paypal.com/cgi-bin/webscr", method: "post", target: "_top"}
     %input{name: "cmd", type: "hidden", value: "_s-xclick"}/
-    %input{name: "hosted_button_id", type: "hidden", value: "KSZ73WW554HP2"}/
+    %input{name: "hosted_button_id", type: "hidden", value: "GFK2C4AJUW3G8"}/
     %input{alt: "PayPal - The safer, easier way to pay online!", border: "0", name: "submit", src: "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif", type: "image"}/
     %img{alt: "", border: "0", height: "1", src: "https://www.paypalobjects.com/en_US/i/scr/pixel.gif", width: "1"}/
-  %h6 Donations go through our fiscal sponsor, School Factory.
+  %h6 All donations are provided to Bridge Foundry, Inc. as #{ link_to "unrestricted funds", "https://rebrand.ly/bridge-foundry-unrestricted-funds" }.
 
   %h6 Email #{ mail_to("hello@railsbridge.org", nil, class: 'inline-link') } for more information.

--- a/app/views/static_pages/projects.html.haml
+++ b/app/views/static_pages/projects.html.haml
@@ -22,8 +22,8 @@
     .feature.js-match-height-item
       .feature-icon.fa.fa-umbrella
       %h4 Bridge Foundry
-      %p We created a new umbrella organization called Bridge Foundry, so that we could help ourselves and like-minded organizations more easily manage the money parts of improving tech. 
-      %p Bridge Foundry is a project of the 501c(3) School Factory, an organization that creates and supports communities and spaces that transform education.
+      %p We created a new umbrella organization called Bridge Foundry, so that we could help ourselves and like-minded organizations more easily manage the money parts of improving tech.
+      %p Bridge Foundry is a non-profit organization that transforms tech culture by generating leaders, teachers and mentors who empower the underserved.
 
 .row.js-match-height
   .col-md-6

--- a/app/views/static_pages/team.html.haml
+++ b/app/views/static_pages/team.html.haml
@@ -84,10 +84,5 @@
 %h2 What is RailsBridge, legally?
 
 %p
-  RailsBridge is not a standalone legal entity; rather, we are a project of #{ link_to "Bridge Foundry", "http://bridgefoundry.org/", target: "_blank", class: 'inline-link'}, an
-  organization empowering people with technology through teaching and facilitating access.
-  Bridge Foundry, in turn, is a project of #{ link_to "School Factory", "http://schoolfactory.org/", target: "_blank", class: 'inline-link' }, a 501(c)3.
-
-%p This is a little complex, so we made you a chart:
-
-%p= image_tag 'railsbridge-structure.png'
+  RailsBridge is not a standalone legal entity; rather, we are a project of #{ link_to "Bridge Foundry", "http://bridgefoundry.org/", target: "_blank", class: 'inline-link'}
+  &mdash; a 501(c)(3) organization empowering people with technology through teaching and facilitating access.


### PR DESCRIPTION
Bridge Foundry is now its own 501(c)(3), separate from School Factory. As an official Bridge of the organization, we need to update any old references and donations buttons to be representative of Bridge Foundry instead.