### PR TITLE
Update Cleveland chapter signup

### DIFF
--- a/app/views/static_pages/chapters.html.haml
+++ b/app/views/static_pages/chapters.html.haml
@@ -121,8 +121,8 @@
       %h4 Cleveland, OH
       %ul
         %li
-          Online at
-          %a.inline-link{ href: "http://clevelandrailsbridge.org/", target: "_blank" } clevelandrailsbridge.org
+          Sign up at
+          %a.inline-link{ href: "http://bridgetroll.org/", target: "_blank" } bridgetroll.org
 .row.js-match-height
   .col-md-4
     .feature.js-match-height-item


### PR DESCRIPTION
Please merge this ASAP. The domain for the site that was originally made for the Cleveland RailsBridge events is no longer registered to anyone associated with RailsBridge. FYI, do **_not_** navigate to the old site, it is NSFW! 😱

## Things Done
- Remove old site as domain is currently registered to a shady organization that is NSFW.

