### PR TITLE
Remove broken RailsBridge Chicago link

### DIFF
--- a/app/views/static_pages/chapters.html.haml
+++ b/app/views/static_pages/chapters.html.haml
@@ -107,9 +107,6 @@
       %h4 Chicago, Illinois
       %ul
         %li
-          Online at
-          %a.inline-link{ href: "http://www.railsbridgechi.com/", target: "_blank" } railsbridgechi.com
-        %li
           Sign up at
           %a.inline-link{ href: "http://www.meetup.com/RailsBridgeChicago/", target: "_blank" } meetup.com/RailsBridgeChicago
         %li


### PR DESCRIPTION
Was just perusing the RailsBridge chapters section and found a dead link :(
![screen shot 2018-05-03 at 7 32 05 pm](https://user-images.githubusercontent.com/6441226/39608689-daffa75a-4f08-11e8-8853-ea4bd66379f6.png)

![screen shot 2018-05-03 at 7 32 33 pm](https://user-images.githubusercontent.com/6441226/39608690-db1135e2-4f08-11e8-88f4-9d5bbd06378f.png)

I'm hoping to become more involved with the Chicago chapter, so hopefully there will be another PR in the future to add it back in :D. But for now, it should probably just be removed.