### PR TITLE
remove DC chapter

### DIFF
--- a/app/views/static_pages/chapters.html.haml
+++ b/app/views/static_pages/chapters.html.haml
@@ -222,15 +222,6 @@
           %a.inline-link{ href: "https://twitter.com/RailsBridgeTri", target: "_blank" } @RailsBridgeTri
           for updates!
 
-  .col-md-4
-    .feature.js-match-height-item
-      %h4 Washington, DC
-      %ul
-        %li
-          Follow
-          %a.inline-link{ href: "https://twitter.com/RailsBridgeDC", target: "_blank" } @RailsBridgeDC
-          for updates!
-
 %h2.gray-underline Global
 
 .row.js-match-height


### PR DESCRIPTION
The RailsBridgeDC twitter account hasn't updated in 5 years. The webpage and Meetup group are both gone.
